### PR TITLE
Fix static image serving

### DIFF
--- a/APP.py
+++ b/APP.py
@@ -478,6 +478,15 @@ def send_functions(filename):
     # Envoie le fichier demandé depuis le dossier "Functions"
     return send_from_directory(functions_dir, filename)
 
+# Cette route permet de servir les fichiers images présents dans le dossier "Images".
+# Elle est nécessaire pour que les icônes utilisées dans les templates soient
+# correctement récupérées par le navigateur.
+@app.route('/Images/<path:filename>')
+def send_images(filename):
+    base_dir = os.path.abspath(os.path.dirname(__file__))
+    images_dir = os.path.join(base_dir, 'Images')
+    return send_from_directory(images_dir, filename)
+
 # Lancement du serveur Flask (production avec debug désactivé)
 if __name__ == '__main__':
     app.run(debug=False)

--- a/Templates/ajouter.html
+++ b/Templates/ajouter.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/Styles/common.css">
     <link rel="stylesheet" href="/Styles/ajouter.css">
-    <link rel="icon" href="Images\Logo.png" type="image/png">
+    <link rel="icon" href="/Images/Logo.png" type="image/png">
     <title>Ajouter écran</title>
 </head>
 <body>

--- a/Templates/ajouterU.html
+++ b/Templates/ajouterU.html
@@ -6,7 +6,7 @@
     <title>Ajouter un Utilisateur</title>
     <link rel="stylesheet" href="/Styles/common.css">
     <link rel="stylesheet" href="/Styles/ajouterU.css">
-    <link rel="icon" href="\Images\Logo.png" type="image/png">
+    <link rel="icon" href="/Images/Logo.png" type="image/png">
 </head>
 <body>
     <!--Page pour ajouter un nouvel utilisateur avec option admin -->

--- a/Templates/ecran.html
+++ b/Templates/ecran.html
@@ -6,7 +6,7 @@
     <title>Tableau écran</title>
     <link rel="stylesheet" href="/Styles/common.css">
     <link rel="stylesheet" href="/Styles/ecran.css">
-    <link rel="icon" href="\Images\Logo.png" type="image/png">
+    <link rel="icon" href="/Images/Logo.png" type="image/png">
 </head>
 <body>
     <!--Affichage du tableau des écrans avec options de filtrage -->

--- a/Templates/index.html
+++ b/Templates/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/Styles/common.css">
     <link rel="stylesheet" href="/Styles/index.css">
-    <link rel="icon" href="\Images\Logo.png" type="image/png">
+    <link rel="icon" href="/Images/Logo.png" type="image/png">
     <title>Accueil</title>
 </head>
 <body>

--- a/Templates/login.html
+++ b/Templates/login.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="/Styles/common.css">
     <!-- Charger les styles spécifiques à la page ensuite -->
     <link rel="stylesheet" href="/Styles/login.css">
-    <link rel="icon" href="\Images\Logo.png" type="image/png">
+    <link rel="icon" href="/Images/Logo.png" type="image/png">
     <title>Connexion</title>
 </head>
 <body>

--- a/Templates/modifier.html
+++ b/Templates/modifier.html
@@ -6,7 +6,7 @@
     <title>Modifier un écran</title>
     <link rel="stylesheet" href="/Styles/common.css">
     <link rel="stylesheet" href="/Styles/modifier.css">
-    <link rel="icon" href="\Images\Logo.png" type="image/png">
+    <link rel="icon" href="/Images/Logo.png" type="image/png">
 </head>
 <body>
     <!--Page de modification d'un écran avec recherche préalable par référence -->

--- a/Templates/prendre.html
+++ b/Templates/prendre.html
@@ -6,7 +6,7 @@
     <title>Prendre écran</title>
     <link rel="stylesheet" href="/Styles/common.css">
     <link rel="stylesheet" href="/Styles/prendre.css">
-    <link rel="icon" href="\Images\Logo.png" type="image/png">
+    <link rel="icon" href="/Images/Logo.png" type="image/png">
 </head>
 <body>
     <!--Page pour prendre un écran -->

--- a/Templates/ranger.html
+++ b/Templates/ranger.html
@@ -6,7 +6,7 @@
     <title>Ranger écrans</title>
     <link rel="stylesheet" href="/Styles/common.css">
     <link rel="stylesheet" href="/Styles/ranger.css">
-    <link rel="icon" href="\Images\Logo.png" type="image/png">
+    <link rel="icon" href="/Images/Logo.png" type="image/png">
 </head>
 <body>
     <!--Page utilisée pour ranger un écran et gérer le statut de lavage -->

--- a/Templates/supprimer.html
+++ b/Templates/supprimer.html
@@ -6,7 +6,7 @@
     <title>Supprimer une référence</title>
     <link rel="stylesheet" href="/Styles/common.css">
     <link rel="stylesheet" href="/Styles/supprimer.css">
-    <link rel="icon" href="\Images\Logo.png" type="image/png">
+    <link rel="icon" href="/Images/Logo.png" type="image/png">
 </head>
 <body>
     <!--Page pour rechercher et supprimer une référence écran -->


### PR DESCRIPTION
## Summary
- serve images through Flask so templates can load icons properly
- use forward slash paths for icon links in templates

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687f2a5c70a8833082d6528b0f3c4ba8