### PR TITLE
Add PyInstaller packaging guide

### DIFF
--- a/APP.py
+++ b/APP.py
@@ -1,5 +1,5 @@
 from flask import *
-import sqlite3, secrets, os, webbrowser, subprocess, platform
+import sqlite3, secrets, os, sys, webbrowser, subprocess, platform
 
 # Configuration d'écran pour Windows
 SCREEN_CONFIG = {
@@ -53,8 +53,9 @@ def open_browser_on_screen(url):
 open_browser_on_screen('http://localhost:5000/')
 
 # Détermination du répertoire de base du projet
-# On récupère le chemin absolu du fichier courant pour définir le répertoire de base
-base_dir = os.path.dirname(os.path.abspath(__file__))
+# Lorsqu'il est empaqueté avec PyInstaller, `sys._MEIPASS` contient le dossier temporaire
+# où se trouvent les ressources. Sinon, on utilise le chemin du fichier courant.
+base_dir = getattr(sys, "_MEIPASS", os.path.dirname(os.path.abspath(__file__)))
 
 # Initialisation de l'application Flask en précisant les dossiers pour les templates et les fichiers statiques (styles)
 app = Flask(
@@ -70,8 +71,7 @@ def generate_secret_key():
 generate_secret_key()
 
 # Définition du chemin vers la base de données SQLite
-project_root = os.path.dirname(os.path.realpath(__file__))
-database = os.path.join(project_root, 'armoire.db')
+database = os.path.join(base_dir, 'armoire.db')
 
 def get_db_connection():
     """Renvoie une connexion à la base de données SQLite.

--- a/readme
+++ b/readme
@@ -126,4 +126,31 @@ Le projet se lance automatiquement grace a la configuration de la raspberry. Dan
    En cas de probleme, lancez la commande :
    flask --app "app.py" run
 4. Le navigateur s’ouvrira automatiquement pour afficher l’application.
-5. Pour terminer le serveur, utilisez Ctrl+C dans l’invite de commande.
+5. Pour terminer le serveur, utilisez Ctrl+C dans l'invite de commande.
+
+## Emballage de l'application
+
+### Utilisation de PyInstaller
+1. Installez PyInstaller :
+   ```bash
+   pip install pyinstaller
+   ```
+2. Depuis la racine du projet, lancez :
+   ```bash
+   pyinstaller --onefile APP.py \
+     --add-data "Templates:Templates" \
+     --add-data "Styles:Styles" \
+     --add-data "Images:Images" \
+     --add-data "armoire.db:."
+   ```
+   Sur Windows, utilisez un point-virgule `;` à la place des deux-points pour les options `--add-data`.
+3. L'exécutable sera créé dans le dossier `dist/`.
+
+### Utilisation d'un `setup.py`
+1. Créez un fichier `setup.py` décrivant les dépendances et les fichiers à inclure.
+2. Exécutez :
+   ```bash
+   python setup.py install
+   ```
+   L'application peut alors être lancée comme n'importe quel paquet installé.
+


### PR DESCRIPTION
## Summary
- clarify `APP.py` file paths so packaging works with PyInstaller
- document how to generate an executable using PyInstaller or setup.py

## Testing
- `python -m py_compile APP.py wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_687f4390ef6c8330b544b317b6abcfd4