### PR TITLE
Ajout de licence et documentation professionnelle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+venv/
+*.py[cod]
+*.pyo
+*.pyd
+.Python
+.env
+.pytest_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Journal des modifications
+
+## [1.0.0] - 2025-08-27
+### Ajouté
+- Publication initiale du projet.
+- Ajout de la licence MIT.
+- Documentation et guide de contribution en français.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Guide de contribution
+
+Merci de votre intérêt pour améliorer ce projet.
+
+## Processus de contribution
+1. *Forkez* le dépôt et créez votre branche (`git checkout -b ma-fonctionnalite`).
+2. Assurez-vous que les dépendances sont installées et que les tests s'exécutent correctement.
+3. Effectuez vos modifications en respectant les normes de code.
+4. Commitez vos changements (`git commit -am 'Ajout de ma fonctionnalité'`).
+5. Poussez la branche (`git push origin ma-fonctionnalite`) et ouvrez une *pull request*.
+
+## Normes de code
+- Respecter la syntaxe Python 3 et les conventions PEP 8.
+- Documenter les fonctions et modules significatifs.
+- Ajouter des tests pour les nouvelles fonctionnalités si possible.
+
+## Rapport de bogues
+Si vous trouvez un bug, veuillez ouvrir une *issue* en décrivant :
+- Le contexte et les étapes pour reproduire le problème.
+- Le comportement attendu.
+- Des captures d'écran ou journaux utiles.
+
+## Questions
+Pour toute question supplémentaire, n'hésitez pas à ouvrir une *issue* afin de démarrer la discussion.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Licence MIT (MIT)
+
+Copyright (c) 2025 Les contributeurs du projet
+
+Par la présente, l'autorisation est accordée, gratuitement, à toute personne obtenant une copie
+de ce logiciel et des fichiers de documentation associés (le « Logiciel »), de traiter
+le Logiciel sans restriction, y compris sans limitation les droits
+d'utiliser, de copier, de modifier, de fusionner, de publier, de distribuer, de concéder une sous-licence et/ou de vendre
+des copies du Logiciel, et de permettre aux personnes auxquelles le Logiciel est
+fourni de le faire, sous réserve des conditions suivantes :
+
+La notice de droit d'auteur ci-dessus et la présente notice d'autorisation doivent être incluses dans toutes
+les copies ou parties substantielles du Logiciel.
+
+LE LOGICIEL EST FOURNI « TEL QUEL », SANS GARANTIE D'AUCUNE SORTE, EXPRESSE OU IMPLICITE,
+Y COMPRIS MAIS SANS S'Y LIMITER LES GARANTIES DE QUALITÉ MARCHANDE,
+D'ADÉQUATION À UN USAGE PARTICULIER ET D'ABSENCE DE CONTREFAÇON.
+EN AUCUN CAS LES AUTEURS OU TITULAIRES DU COPYRIGHT NE SERONT RESPONSABLES DE TOUTE RÉCLAMATION,
+DE DOMMAGES OU AUTRE RESPONSABILITÉ, QUE CE SOIT DANS UNE ACTION CONTRACTUELLE, DÉLICTUELLE OU AUTRE,
+PROVENANT DE, OU EN LIEN AVEC LE LOGICIEL OU L'UTILISATION OU D'AUTRES TRANSACTIONS DANS LE LOGICIEL.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# Documentation du Projet Sérigraphie
+# RPI LocalWebServer
 
-## Présentation du Projet
+Application web développée avec Flask pour gérer des sérigraphies sur une Raspberry Pi. Elle permet de suivre l'état des écrans, d'administrer les utilisateurs et de déployer facilement le service sur un environnement embarqué.
 
-Ce projet est une application web développée avec Flask qui permet de gérer des sérigraphies. L’application se connecte à une base de données SQLite ([armoire.db](armoire.db)), gère les utilisateurs et permet d'ajouter, modifier, supprimer et gérer le statut des sérigraphies (prise, rangement, etc.).
+## Fonctionnalités
+
+- Ajout, modification, suppression et suivi des sérigraphies.
+- Authentification des utilisateurs et gestion des administrateurs.
+- Déploiement automatique sur Raspberry Pi (service systemd et lancement de Firefox en mode kiosque).
 
 ## Structure du Projet
 
@@ -11,7 +15,7 @@ Le projet est organisé comme suit :
 - **Racine du projet**  
   - `APP.py` : Point d'entrée principal de l’application. Il configure Flask, définit les routes et gère la connexion à la base de données via la fonction [`get_db_connection`](app.py#L11).
   - `armoire.db` : Fichier SQLite contenant les données des sérigraphies et des utilisateurs.
-  - `readme` : Ce fichier, qui contient désormais toutes les explications pour comprendre le projet.
+  - `README.md` : Documentation principale du projet.
   
 - **Dossier Templates/**  
   Contient tous les fichiers HTML utilisés pour l’affichage des pages. Chaque page utilise un fichier CSS dédié (situé dans le dossier Styles) et certains liens spécifiques dans les balises `<link>` permettent d’inclure une icône pour l’onglet du navigateur ([Logo.png](Images/Logo.png)).
@@ -147,3 +151,15 @@ générer un programme autonome contenant l'application et toutes ses ressources
 4. L'exécutable sera créé dans le dossier `dist\APP\APP.exe`. Copiez ce
    dossier sur la machine souhaitée puis lancez `APP.exe` pour démarrer le
    serveur.
+
+## Contribuer
+
+Les contributions sont les bienvenues ! Merci de consulter le fichier [CONTRIBUTING.md](CONTRIBUTING.md) pour connaître les bonnes pratiques et le processus de soumission.
+
+## Licence
+
+Ce projet est distribué sous la licence MIT. Voir le fichier [LICENSE](LICENSE) pour plus d'informations.
+
+## Historique des versions
+
+Les changements notables de chaque version sont documentés dans le fichier [CHANGELOG.md](CHANGELOG.md).


### PR DESCRIPTION
## Résumé
- Ajout d'un fichier de licence MIT en français
- Restructuration de la documentation principale et conversion en README.md
- Ajout d'un guide de contribution, d'un journal des modifications et d'un `.gitignore`

## Tests
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aeaaa703e883309a58c2694d7cbe47